### PR TITLE
feat: Add exploration preference for personalized food recommendation diversity

### DIFF
--- a/app/app/screens/OnboardingScreen.tsx
+++ b/app/app/screens/OnboardingScreen.tsx
@@ -13,6 +13,7 @@ interface UserPreferences {
   spicy_level: number
   sweet_level: number
   salty_level: number
+  exploration_preference: number
   allergies: string[]
   disliked_ingredients: string[]
   favorite_cuisines: string[]
@@ -63,6 +64,7 @@ export const OnboardingScreen = observer(function OnboardingScreen({ navigation 
     spicy_level: 2,
     sweet_level: 2,
     salty_level: 2,
+    exploration_preference: 2.5,
     allergies: [],
     disliked_ingredients: [],
     favorite_cuisines: []
@@ -177,6 +179,31 @@ export const OnboardingScreen = observer(function OnboardingScreen({ navigation 
         {renderSlider('Sweet', preferences.sweet_level, 'Not Sweet', 'Very Sweet', 'sweet_level')}
         {renderSlider('Salty', preferences.salty_level, 'Not Salty', 'Very Salty', 'salty_level')}
         {renderSlider('Spicy', preferences.spicy_level, 'Not Spicy', 'Very Spicy', 'spicy_level')}
+      </View>
+
+      <View style={$sliderContainer}>
+        <Text style={$sliderLabel}>
+          Food Exploration: {preferences.exploration_preference.toFixed(1)}
+        </Text>
+        <Text style={$sliderDescription}>
+          How adventurous are you with food?
+        </Text>
+        <View style={$explorationLabels}>
+          <Text style={$explorationLabelText}>Familiar</Text>
+          <Text style={$explorationLabelText}>Adventurous</Text>
+        </View>
+        <View style={$sliderTrack}>
+          {[0, 1, 2, 3, 4, 5].map((value) => (
+            <TouchableOpacity
+              key={value}
+              style={[
+                $sliderDot,
+                value <= preferences.exploration_preference ? $sliderDotActive : $sliderDotInactive
+              ]}
+              onPress={() => updatePreference('exploration_preference', value)}
+            />
+          ))}
+        </View>
       </View>
     </View>
   )
@@ -407,6 +434,24 @@ const $sliderLabel: TextStyle = {
 const $sliderTrackWrapper: ViewStyle = {
   height: 40,
   justifyContent: "center",
+}
+
+const $sliderDescription: TextStyle = {
+  fontSize: 14,
+  color: colors.palette.neutral600,
+  marginBottom: spacing.xs,
+}
+
+const $explorationLabels: ViewStyle = {
+  flexDirection: "row",
+  justifyContent: "space-between",
+  marginBottom: spacing.xs,
+}
+
+const $explorationLabelText: TextStyle = {
+  fontSize: 12,
+  color: colors.palette.neutral500,
+  fontStyle: "italic",
 }
 
 const $sliderTrack: ViewStyle = {

--- a/server/recommendation_system/api.py
+++ b/server/recommendation_system/api.py
@@ -309,11 +309,15 @@ def recommend_menu(request):
         user_id = request.user.username  # 인증된 사용자의 username 사용
         
         # DB에서 유저의 온보딩 정보 조회
+        exploration_preference = 2.5  # 기본값
         try:
             # 커스텀 User 모델 사용
             from users.models import User
             user = request.user  # 이미 인증된 사용자
             user_preference = UserPreference.objects.get(user=user)
+            
+            # exploration_preference 가져오기
+            exploration_preference = user_preference.exploration_preference
             
             # DB에서 가져온 정보로 onboarding_data 구성
             onboarding_data = {
@@ -398,8 +402,8 @@ def recommend_menu(request):
             score = scorer.calculate_hybrid_score(similarity_score, item_data, search_context)
             scored_results.append((menu_doc, score))
         
-        # MMR 리랭킹 적용
-        reranker = MMRReranker()
+        # MMR 리랭킹 적용 (exploration_preference 사용)
+        reranker = MMRReranker(exploration_preference=exploration_preference)
         final_results = reranker.rerank_with_mmr(scored_results, max_results)
         
         # 결과 포맷팅
@@ -459,6 +463,9 @@ def recommend_place(request):
         gallery_analysis = data.get('gallery_analysis')
         behavior_data = data.get('behavior_data')
         
+        # exploration_preference 가져오기 (기본값 2.5)
+        exploration_preference = onboarding_data.get('exploration_preference', 2.5)
+        
         user_profile_text = user_profile_service.create_user_profile(
             user_id, onboarding_data, gallery_analysis, behavior_data
         )
@@ -507,8 +514,8 @@ def recommend_place(request):
             score = scorer.calculate_hybrid_score(similarity_score, item_data, search_context)
             scored_results.append((place_doc, score))
         
-        # MMR 리랭킹 적용
-        reranker = MMRReranker()
+        # MMR 리랭킹 적용 (exploration_preference 사용)
+        reranker = MMRReranker(exploration_preference=exploration_preference)
         final_results = reranker.rerank_with_mmr(scored_results, max_results)
         
         # 결과 포맷팅

--- a/server/recommendation_system/scoring.py
+++ b/server/recommendation_system/scoring.py
@@ -233,9 +233,19 @@ class HybridScorer:
 class MMRReranker:
     """MMR 리랭크 클래스"""
     
-    def __init__(self, lambda_param: float = 0.7):
-        self.lambda_param = lambda_param  # 다양성 vs 관련성 균형
+    def __init__(self, lambda_param: float = None, exploration_preference: float = None):
+        # exploration_preference가 주어진 경우 동적으로 lambda 계산
+        if exploration_preference is not None:
+            # 0 (familiar) -> lambda=0.9 (관련성 중시)
+            # 5 (adventurous) -> lambda=0.3 (다양성 중시)
+            self.lambda_param = 0.9 - (exploration_preference / 5.0) * 0.6
+        elif lambda_param is not None:
+            self.lambda_param = lambda_param
+        else:
+            self.lambda_param = 0.7  # 기본값
+        
         self.logger = logging.getLogger(__name__)
+        self.logger.info(f"MMR initialized with lambda={self.lambda_param:.2f}")
     
     def rerank_with_mmr(self, items: List[Tuple[Any, float]], 
                        max_results: int = 20) -> List[Tuple[Any, float]]:

--- a/server/users/migrations/0003_add_exploration_preference.py
+++ b/server/users/migrations/0003_add_exploration_preference.py
@@ -1,0 +1,19 @@
+# Generated manually for exploration_preference field
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0002_user_created_at_user_nickname_userpreference_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userpreference',
+            name='exploration_preference',
+            field=models.FloatField(default=2.5, help_text='0=familiar foods, 5=adventurous'),
+        ),
+    ]
+

--- a/server/users/models.py
+++ b/server/users/models.py
@@ -39,6 +39,7 @@ class UserPreference(models.Model):
     spicy_level = models.PositiveSmallIntegerField(default=0)
     sweet_level = models.PositiveSmallIntegerField(default=0)
     salty_level = models.PositiveSmallIntegerField(default=0)
+    exploration_preference = models.FloatField(default=2.5, help_text="0=familiar foods, 5=adventurous")
     allergies = models.JSONField(default=list, blank=True)
     disliked_ingredients = models.JSONField(default=list, blank=True)
     favorite_cuisines = models.JSONField(default=list, blank=True)

--- a/server/users/serializers.py
+++ b/server/users/serializers.py
@@ -49,6 +49,7 @@ class UserPreferenceSerializer(serializers.ModelSerializer):
             "spicy_level", 
             "sweet_level", 
             "salty_level", 
+            "exploration_preference",
             "allergies", 
             "disliked_ingredients", 
             "favorite_cuisines", 
@@ -69,6 +70,11 @@ class UserPreferenceSerializer(serializers.ModelSerializer):
     def validate_salty_level(self, value):
         if value < 0 or value > 10:
             raise serializers.ValidationError("Salty level must be between 0 and 10")
+        return value
+    
+    def validate_exploration_preference(self, value):
+        if value < 0 or value > 5:
+            raise serializers.ValidationError("Exploration preference must be between 0 and 5")
         return value
 
 


### PR DESCRIPTION
## Summary
사용자의 음식 추천 받는 성향에 따라 추천 결과 다양성을 조절할 수 있는 exploration_preference 기능 추가

##Features
- 온보딩 슬라이더 추가: "Familiar (0) ↔ Adventurous (5)"
- MMR lambda 자동 조정: 0→0.9 (관련성↑), 5→0.3 (다양성↑)

## Files (6개)
OnboardingScreen.tsx, models.py, serializers.py, scoring.py, api.py, migration

## Breaking Changes
없음 