### PR TITLE
feat(reco):save image CLIP embeddings to ChromaDB and tune MMR by image diversity

### DIFF
--- a/server/recommendation_system/api.py
+++ b/server/recommendation_system/api.py
@@ -21,8 +21,8 @@ from rest_framework import status
 
 from .user_profile import UserProfileService, create_sample_user_profile
 from .scoring import SearchContext, HybridScorer, MMRReranker, RecommendationReranker
-# ChromaDB 관련 import (더 이상 사용 안함 - client.py로 대체)
-# from . import EmbeddingService, VectorIndexBuilder, RecommendationEngine
+# Chroma 기반 유틸 사용(사용자 갤러리 다양성 → exploration_preference 보정)
+from . import VectorIndexBuilder  # alias to ChromaVectorIndexBuilder
 from users.models import UserPreference
 
 logger = logging.getLogger(__name__)
@@ -247,7 +247,16 @@ def recommend_menu(request):
                 'budget_range': data.get('budget_range', [0, 0]),
                 'distance_preference': data.get('distance_preference', 2.0)
             }
-        
+        # 갤러리 카테고리 다양성 기반 exploration_preference 보정
+        try:
+            vib = VectorIndexBuilder(None, './chroma_db')
+            ep_from_gallery = vib.get_user_category_exploration_preference(request.user.id, min_images=10)
+            if ep_from_gallery is not None:
+                exploration_preference = ep_from_gallery
+                logger.info(f"갤러리 기반 exploration_preference 적용: {exploration_preference}")
+        except Exception as e:
+            logger.warning(f"갤러리 기반 exploration_preference 계산 실패: {e}")
+
         gallery_analysis = data.get('gallery_analysis')
         behavior_data = data.get('behavior_data')
         

--- a/server/recommendation_system/chroma_index.py
+++ b/server/recommendation_system/chroma_index.py
@@ -9,6 +9,8 @@ import logging
 from typing import Dict, List, Optional, Tuple, Any
 from pathlib import Path
 import os
+import math
+from collections import Counter
 
 import numpy as np
 
@@ -361,6 +363,57 @@ class ChromaVectorIndexBuilder:
             self.logger.error(f"가게 검색 실패: {e}")
             return []
     
+    # 사용자 갤러리 이미지 임베딩을 저장/검색하는 전용 컬렉션을 반환
+    def get_user_images_collection(self):
+        self._initialize_chroma()
+        return self.client.get_or_create_collection(
+            name="user_images",
+            metadata={"hnsw:space": "cosine"},
+        )
+    # user_images 컬렉션에 단일 이미지 임베딩을 upsert(insert or update)
+    def add_user_image_embedding(self, *, user_id: int, image_id: str, embedding: list[float], image_url: str, category: str | None = None):
+        col = self.get_user_images_collection()
+        meta = {"user_id": user_id, "image_url": image_url}
+        if category:
+            meta["category"] = category
+        col.upsert(
+            ids=[f"userimg:{image_id}"],
+            embeddings=[embedding],
+            metadatas=[meta],
+            documents=[image_url],   # 선택
+        )        
+
+    def get_user_category_exploration_preference(self, user_id: int, min_images: int = 10) -> Optional[float]:
+        """유저의 갤러리 카테고리 분포로 탐험성 점수(0~5) 계산.
+
+        - 이미지가 충분치 않으면 None 반환(기존 온보딩/DB 값을 사용하도록).
+        - 계산식: 카테고리 분포의 엔트로피를 정규화(0~1) 후 0~5 스케일로 매핑.
+        """
+        if not CHROMADB_AVAILABLE or not self.client:
+            return None
+
+        try:
+            col = self.get_user_images_collection()
+            res = col.get(where={"user_id": user_id}, include=["metadatas"])
+            metas = (res or {}).get("metadatas") or []
+            cats = [m.get("category") for m in metas if m and m.get("category")]
+            if len(cats) < min_images:
+                return None
+
+            cnt = Counter(cats)
+            total = sum(cnt.values())
+            if total == 0:
+                return None
+            ps = [c / total for c in cnt.values()]
+            H = -sum(p * math.log(p + 1e-12) for p in ps)
+            Hmax = math.log(len(ps)) if ps else 0.0
+            Hnorm = 0.0 if Hmax == 0.0 else H / Hmax  # 0~1
+            return round(5.0 * Hnorm, 2)
+        except Exception as e:
+            self.logger.error(f"탐험성 계산 실패: {e}")
+            return None
+
+
     def get_collection_info(self) -> Dict[str, Any]:
         """컬렉션 정보 조회"""
         if not CHROMADB_AVAILABLE or not self.client:

--- a/server/users/image_utils.py
+++ b/server/users/image_utils.py
@@ -5,6 +5,7 @@ import torch
 from PIL import Image
 from transformers import CLIPProcessor, CLIPModel
 from io import BytesIO
+import numpy as np
 
 # =====================
 # Setup
@@ -76,3 +77,41 @@ def get_food_image_category(url: str) -> tuple[str, float]:
     image_bytes = _read_image_from_s3(url)
     food_categories = _get_food_categories()
     return _predict_category_from_bytes(image_bytes, food_categories)
+
+def get_clip_embedding_from_bytes(image_bytes: bytes) -> list[float]:
+    image = Image.open(BytesIO(image_bytes)).convert("RGB")
+    inputs = processor(images=[image], return_tensors="pt").to(device)
+    with torch.no_grad():
+        feats = model.get_image_features(**inputs)  # [1, D]
+    vec = feats[0].cpu().numpy().astype(np.float32)
+    vec = vec / (np.linalg.norm(vec) + 1e-12)      # cosine용 정규화
+    return vec.tolist()
+
+def normalize_to_onboarding_category(label: str) -> tuple[str, str]:
+    """주어진 한글 카테고리/키워드를 온보딩 카테고리(id, label)로 매핑.
+    매칭 실패 시 ('other', '기타') 반환.
+    """
+    if not label:
+        return ("other", "기타")
+    t = str(label).lower()
+    rules = [
+        (['한식','korean'], ('korean','한식')),
+        (['일식','japanese','초밥','스시','라멘'], ('japanese','일식')),
+        (['중식','chinese','짜장','짬뽕','마라'], ('chinese','중식')),
+        (['이탈','파스타','피자','italian'], ('italian','이탈리안')),
+        (['멕시','taco','burrito','mexican'], ('mexican','멕시칸')),
+        (['인도','커리','난','indian'], ('indian','인도')),
+        (['아메리칸','미국','버거','치킨','american'], ('american','아메리칸')),
+        (['태국','thai','팟타이'], ('thai','태국')),
+        (['지중해','그리스','mediterranean'], ('mediterranean','지중해')),
+        (['프렌치','프랑스','french'], ('french','프렌치')),
+        (['베트남','쌀국수','banh','vietnam'], ('vietnamese','베트남')),
+        (['스페인','타파스','paella','spanish'], ('spanish','스페인')),
+    ]
+    for keywords, result in rules:
+        if any(k in t for k in keywords):
+            return result
+    # 베이커리/디저트/카페 등은 임시로 아메리칸으로 묶음
+    if any(k in t for k in ['베이커리','디저트','카페','bakery','dessert','cafe']):
+        return ('american','아메리칸')
+    return ("other", "기타")

--- a/server/users/services.py
+++ b/server/users/services.py
@@ -1,9 +1,8 @@
 from django.db import transaction
 from django.shortcuts import get_object_or_404
-
-from .image_utils import get_food_image_category
 from .models import User, Profile, Follow, UserGalleryImage
-
+from .image_utils import _read_image_from_s3, get_clip_embedding_from_bytes, get_food_image_category, normalize_to_onboarding_category
+from recommendation_system.chroma_index import ChromaVectorIndexBuilder
 
 @transaction.atomic
 def create_user_with_profile(*, username: str, email: str, password: str, bio: str = "", preferences: dict | None = None) -> User:
@@ -56,11 +55,27 @@ def list_follow_suggestions(*, user: User, limit: int = 10):
         .order_by("-date_joined")[:limit]
     )
 
-@transaction.atomic
-def upload_user_photo(*, user: User, photo_url: str) -> str:
-    photo = UserGalleryImage.objects.create(user=user, image_url=photo_url)
-    photo.category_tag = get_food_image_category(photo_url)[0]
-    return photo
 
-def list_user_photos(*, user: User):
-    return UserGalleryImage.objects.filter(user=user).order_by("-created_at")
+def upload_user_photo(*, user: User, photo_url: str):
+    photo = UserGalleryImage.objects.create(user=user, image_url=photo_url)
+
+    img_bytes = _read_image_from_s3(photo_url)
+    emb = get_clip_embedding_from_bytes(img_bytes)
+
+    vib = ChromaVectorIndexBuilder(embedding_service=None, persist_directory="./chroma_db")
+    # 카테고리 예측은 실패해도 무시(임베딩 저장은 계속 수행)
+    try:
+        raw_category, _ = get_food_image_category(photo_url)
+    except Exception:
+        raw_category = None
+    category_id, category_label = normalize_to_onboarding_category(raw_category or "")
+
+    vib.add_user_image_embedding(
+        user_id=user.id,
+        image_id=str(photo.id),
+        embedding=emb,
+        image_url=photo_url,
+        category=category_label,
+        category_id=category_id,
+    )
+    return photo


### PR DESCRIPTION
Add CLIP image embeddings to Chroma and use gallery diversity to tune MMR. 
On photo upload, generate CLIP vectors, normalize categories to onboarding schema, and upsert into Chroma with user metadata. 
At recommend time, derive exploration preference (0–5) from category entropy and adjust MMR lambda accordingly. Django DB still stores only image URLs; vectors live in Chroma.