### PR TITLE
feat: 스크랩 토글 시 카테고리 선호도 동기화

### DIFF
--- a/server/recommendation_system/api.py
+++ b/server/recommendation_system/api.py
@@ -506,17 +506,35 @@ def calculate_menu_similarity(menu: Dict, onboarding_data: Dict, embedding_servi
         score = 0.0
         weight_sum = 0.0
         
-        # 1. 카테고리 매칭 (가중치: 0.4)
+        # 1. 카테고리 매칭 (가중치: 0.35)
         preferred_categories = onboarding_data.get('preferred_categories', [])
         if preferred_categories:
             menu_category = menu.get('category', '')
             # category_normalized 사용
             menu_category_normalized = menu.get('category_normalized', menu_category)
             if menu_category_normalized in preferred_categories:
-                score += 0.4
-            weight_sum += 0.4
+                score += 0.35
+            weight_sum += 0.35
+
+        # 2. 스크랩 기반 카테고리 선호도 (가중치: 0.15)
+        scrap_category_prefs = onboarding_data.get('scrap_category_preferences', {})
+        if scrap_category_prefs:
+            category_scores = scrap_category_prefs.get('category_preferences', {})
+            menu_category = menu.get('category', '')
+            menu_category_normalized = menu.get('category_normalized', menu_category)
+
+            if menu_category_normalized in category_scores:
+                scrap_score = category_scores[menu_category_normalized]
+                score += 0.15 * scrap_score
+            elif menu.get('name'):
+                inferred_category = extract_category_from_menu_name(menu['name'])
+                if inferred_category in category_scores:
+                    scrap_score = category_scores[inferred_category]
+                    score += 0.15 * scrap_score * 0.7
+
+            weight_sum += 0.15
         
-        # 2. 키워드 매칭 (가중치: 0.3)
+        # 3. 키워드 매칭 (가중치: 0.25)
         menu_keywords = menu.get('keywords', [])
         if menu_keywords and isinstance(menu_keywords, list):
             # 사용자 선호 키워드와 비교
@@ -531,21 +549,21 @@ def calculate_menu_similarity(menu: Dict, onboarding_data: Dict, embedding_servi
                 overlap = len(menu_keywords_set.intersection(liked_keywords))
                 if len(menu_keywords_set) > 0:
                     keyword_score = overlap / len(menu_keywords_set)
-                    score += 0.3 * keyword_score
-            weight_sum += 0.3
+                    score += 0.25 * keyword_score
+            weight_sum += 0.25
         
-        # 3. 가격 적합도 (가중치: 0.2)
+        # 4. 가격 적합도 (가중치: 0.15)
         budget_range = onboarding_data.get('budget_range', [0, 0])
         menu_price = menu.get('price', 0)
         if budget_range[0] > 0 or budget_range[1] > 0:
             if budget_range[0] <= menu_price <= budget_range[1]:
-                score += 0.2
+                score += 0.15
             elif menu_price < budget_range[0]:
                 # 예산보다 저렴하면 부분 점수
-                score += 0.1
-            weight_sum += 0.2
+                score += 0.075
+            weight_sum += 0.15
         
-        # 4. 임베딩 유사도 (옵션, 가중치: 0.1)
+        # 5. 임베딩 유사도 (옵션, 가중치: 0.1)
         if embedding_service and menu.get('embedding_vector'):
             # 사용자 프로필 텍스트와 메뉴 임베딩 비교
             # 향후 구현 가능
@@ -895,6 +913,21 @@ def _recommend_menu_internal(request, phase=None):
 
         context_info = process_query_context(query_text, onboarding_data, request.user)
         enhanced_onboarding_data = context_info.get('enhanced_preferences', onboarding_data)
+
+        # 스크랩 기반 카테고리 선호도 적용
+        try:
+            scrap_service = ScrapCategoryPreferenceService(request.user)
+            scrap_prefs = scrap_service.get_category_preference_profile()
+            enhanced_onboarding_data['scrap_category_preferences'] = scrap_prefs
+
+            existing_categories = set(enhanced_onboarding_data.get('preferred_categories', []))
+            scrap_top_categories = set(scrap_prefs.get('top_categories', []))
+            merged_categories = list(existing_categories | scrap_top_categories)[:10]
+            enhanced_onboarding_data['preferred_categories'] = merged_categories
+
+            logger.info(f"User {request.user.id} scrap-based categories: {scrap_prefs.get('top_categories', [])}")
+        except Exception as e:
+            logger.debug(f"Could not add scrap category preferences: {e}")
 
         # 검색 컨텍스트 생성 (쿼리 컨텍스트로 강화된 선호도 사용)
         search_context = SearchContext(

--- a/server/recommendation_system/preference_aggregator.py
+++ b/server/recommendation_system/preference_aggregator.py
@@ -1,11 +1,14 @@
 """
+
 User Preference Aggregation System
 
 Aggregates user preferences from multiple sources:
+
 - Taste preferences (spicy, sweet, salty, oily, chewy)
 - Allergies and disliked ingredients
 - Favorite cuisines
 - Recent food images (inferred food types)
+- Scrap-based category preferences (NEW)
 """
 
 from typing import Dict, List, Any
@@ -79,8 +82,14 @@ class UserPreferenceAggregator:
         # 4. Inferred food interests from gallery images
         food_interests = self._get_food_interests()
 
-        # 5. Calculate confidence scores
-        confidence = self._calculate_confidence(taste_prefs, allergies, dislikes, food_interests)
+        # 5. Scrap-based category preferences (NEW)
+        scrap_category_prefs = self._get_scrap_category_preferences()
+
+        # 6. Merge cuisines with scrap-based preferences
+        merged_cuisines = self._merge_cuisine_preferences(cuisines, scrap_category_prefs)
+
+        # 7. Calculate confidence scores
+        confidence = self._calculate_confidence(taste_prefs, allergies, dislikes, food_interests, scrap_category_prefs)
 
         return {
             'user_id': self.user.id,
@@ -88,8 +97,9 @@ class UserPreferenceAggregator:
             'taste_preferences': taste_prefs,
             'allergies': allergies,
             'disliked_ingredients': dislikes,
-            'favorite_cuisines': cuisines,
+            'favorite_cuisines': merged_cuisines,
             'inferred_food_interests': food_interests,
+            'scrap_category_preferences': scrap_category_prefs,  # NEW
             'exploration_preference': self.preference.exploration_preference,
             'confidence': confidence,
             'total_gallery_images': self._get_total_gallery_images(),
@@ -151,8 +161,60 @@ class UserPreferenceAggregator:
 
         return result
 
+    def _get_scrap_category_preferences(self) -> Dict[str, Any]:
+        """
+        Get category preferences based on user's scrapped restaurants
+
+        Returns:
+            {
+                'category_counts': {'중식': 5, '한식': 3},
+                'category_preferences': {'중식': 0.625, '한식': 0.375},
+                'top_categories': ['중식', '한식'],
+                'total_scraps': 8
+            }
+        """
+        try:
+            from users.scrap_category_service import ScrapCategoryPreferenceService
+            service = ScrapCategoryPreferenceService(self.user)
+            return service.get_category_preference_profile()
+        except Exception as e:
+            logger.warning(f"Error getting scrap category preferences: {e}")
+            return {
+                'category_counts': {},
+                'category_preferences': {},
+                'top_categories': [],
+                'total_scraps': 0
+            }
+
+    def _merge_cuisine_preferences(self, explicit_cuisines: List[str],
+                                   scrap_prefs: Dict[str, Any]) -> List[str]:
+        """
+        Merge explicit cuisine preferences with scrap-based preferences
+
+        Priority: Explicit > Scrap-based
+        """
+        explicit_set = set(explicit_cuisines or [])
+        scrap_top = set(scrap_prefs.get('top_categories', []))
+
+        # Merge with explicit cuisines taking priority
+        merged = list(explicit_set | scrap_top)
+
+        # Sort by preference score (scrap-based scores for those available)
+        scrap_scores = scrap_prefs.get('category_preferences', {})
+
+        def sort_key(cuisine):
+            # Explicit cuisines get score 2.0, scrap-based get their score
+            if cuisine in explicit_set and cuisine not in scrap_top:
+                return 2.0
+            return scrap_scores.get(cuisine, 0.5)
+
+        merged.sort(key=sort_key, reverse=True)
+
+        return merged[:10]  # Limit to top 10
+
     def _calculate_confidence(self, taste_prefs: Dict, allergies: List,
-                              dislikes: List, food_interests: Dict) -> Dict[str, float]:
+                              dislikes: List, food_interests: Dict,
+                              scrap_prefs: Dict = None) -> Dict[str, float]:
         """
         Calculate confidence scores for each preference category
 
@@ -172,17 +234,26 @@ class UserPreferenceAggregator:
         # Max confidence at 10 images
         food_interest_score = min(1.0, num_images / 10)
 
-        # Overall confidence: weighted average
+        # Scrap category confidence: Based on number of scraps (NEW)
+        scrap_score = 0.0
+        if scrap_prefs:
+            total_scraps = scrap_prefs.get('total_scraps', 0)
+            # Max confidence at 10 scraps
+            scrap_score = min(1.0, total_scraps / 10)
+
+        # Overall confidence: weighted average (updated weights)
         overall = (
-            taste_score * 0.3 +
-            allergen_score * 0.2 +
-            food_interest_score * 0.5
+            taste_score * 0.25 +
+            allergen_score * 0.15 +
+            food_interest_score * 0.35 +
+            scrap_score * 0.25  # NEW: scrap-based preference weight
         )
 
         return {
             'taste': round(taste_score, 2),
             'allergies': round(allergen_score, 2),
             'food_interests': round(food_interest_score, 2),
+            'scrap_categories': round(scrap_score, 2),  # NEW
             'overall': round(overall, 2),
         }
 

--- a/server/users/scrap_category_service.py
+++ b/server/users/scrap_category_service.py
@@ -1,0 +1,395 @@
+"""
+
+Scrap-based Category Preference Service
+
+스크랩한 음식점의 카테고리를 분석하여 사용자의 카테고리 선호도를 계산하고
+추천 알고리즘에 반영합니다.
+"""
+
+from typing import Dict, List, Tuple
+from collections import Counter
+from django.db.models import Count
+from users.models import User, UserPreference, UserRemoteScrap
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# 카테고리 정규화 매핑
+# 메뉴/음식점 이름에서 추출한 카테고리를 표준 카테고리로 매핑
+CATEGORY_MAPPING = {
+    # 중식
+    '중식': '중식',
+    '중국집': '중식',
+    '중국요리': '중식',
+    '중화요리': '중식',
+    '마라탕': '중식',
+    '마라샹궈': '중식',
+    '꿔바로우': '중식',
+    '짜장면': '중식',
+    '짬뽕': '중식',
+    '탕수육': '중식',
+    '양꼬치': '중식',
+    '훠궈': '중식',
+    '딤섬': '중식',
+
+    # 한식
+    '한식': '한식',
+    '한정식': '한식',
+    '국밥': '한식',
+    '설렁탕': '한식',
+    '삼겹살': '한식',
+    '갈비': '한식',
+    '불고기': '한식',
+    '비빔밥': '한식',
+    '김치찌개': '한식',
+    '된장찌개': '한식',
+    '순두부': '한식',
+    '칼국수': '한식',
+    '냉면': '한식',
+    '족발': '한식',
+    '보쌈': '한식',
+    '찜닭': '한식',
+    '해장국': '한식',
+    '감자탕': '한식',
+    '삼계탕': '한식',
+    '추어탕': '한식',
+    '곱창': '한식',
+    '막창': '한식',
+    '떡볶이': '한식',
+    '분식': '한식',
+    '김밥': '한식',
+    '라면': '한식',
+    '백반': '한식',
+    '정식': '한식',
+
+    # 일식
+    '일식': '일식',
+    '일본요리': '일식',
+    '스시': '일식',
+    '초밥': '일식',
+    '사시미': '일식',
+    '회': '일식',
+    '라멘': '일식',
+    '우동': '일식',
+    '소바': '일식',
+    '돈카츠': '일식',
+    '돈가스': '일식',
+    '카츠': '일식',
+    '덮밥': '일식',
+    '규동': '일식',
+    '오마카세': '일식',
+    '이자카야': '일식',
+    '야키토리': '일식',
+    '타코야키': '일식',
+    '텐동': '일식',
+    '텐푸라': '일식',
+
+    # 양식
+    '양식': '양식',
+    '파스타': '양식',
+    '피자': '양식',
+    '스테이크': '양식',
+    '햄버거': '양식',
+    '버거': '양식',
+    '샐러드': '양식',
+    '브런치': '양식',
+    '오믈렛': '양식',
+    '리조또': '양식',
+    '그라탕': '양식',
+
+    # 치킨
+    '치킨': '치킨',
+    '닭갈비': '치킨',
+    '치맥': '치킨',
+    '통닭': '치킨',
+    '후라이드': '치킨',
+    '양념치킨': '치킨',
+
+    # 분식/패스트푸드
+    '패스트푸드': '패스트푸드',
+    '맥도날드': '패스트푸드',
+    '버거킹': '패스트푸드',
+    'KFC': '패스트푸드',
+    '롯데리아': '패스트푸드',
+
+    # 해산물
+    '해산물': '해산물',
+    '횟집': '해산물',
+    '조개': '해산물',
+    '게': '해산물',
+    '새우': '해산물',
+    '랍스터': '해산물',
+    '아귀찜': '해산물',
+    '생선구이': '해산물',
+    '해물탕': '해산물',
+
+    # 아시안
+    '아시안': '아시안',
+    '베트남': '아시안',
+    '쌀국수': '아시안',
+    '분짜': '아시안',
+    '반미': '아시안',
+    '태국': '아시안',
+    '팟타이': '아시안',
+    '똠양꿍': '아시안',
+    '인도': '아시안',
+    '커리': '아시안',
+    '난': '아시안',
+    '탄두리': '아시안',
+
+    # 카페/디저트
+    '카페': '카페/디저트',
+    '디저트': '카페/디저트',
+    '케이크': '카페/디저트',
+    '빵': '카페/디저트',
+    '베이커리': '카페/디저트',
+    '아이스크림': '카페/디저트',
+    '와플': '카페/디저트',
+    '커피': '카페/디저트',
+
+    # 술집
+    '술집': '술집',
+    '호프': '술집',
+    '맥주': '술집',
+    '포차': '술집',
+    '바': '술집',
+    '소주': '술집',
+    '막걸리': '술집',
+    '전통주': '술집',
+}
+
+# 표준 카테고리 목록
+STANDARD_CATEGORIES = [
+    '한식', '중식', '일식', '양식', '치킨', '패스트푸드',
+    '해산물', '아시안', '카페/디저트', '술집', '기타'
+]
+
+
+def normalize_category(raw_category: str) -> str:
+    """
+    원본 카테고리를 표준 카테고리로 정규화
+
+    Args:
+        raw_category: 원본 카테고리 문자열 (예: "마라탕", "중국집>중식당")
+
+    Returns:
+        정규화된 카테고리 (예: "중식")
+    """
+    if not raw_category:
+        return '기타'
+
+    # 소문자로 변환하고 공백 제거
+    category_lower = raw_category.lower().strip()
+
+    # 직접 매핑 확인
+    for keyword, normalized in CATEGORY_MAPPING.items():
+        if keyword.lower() in category_lower:
+            return normalized
+
+    # '>' 구분자로 분리된 경우 각 부분 확인
+    if '>' in raw_category:
+        parts = raw_category.split('>')
+        for part in parts:
+            part = part.strip()
+            for keyword, normalized in CATEGORY_MAPPING.items():
+                if keyword.lower() in part.lower():
+                    return normalized
+
+    return '기타'
+
+
+def extract_category_from_menu_name(menu_name: str) -> str:
+    """
+    메뉴 이름에서 카테고리 추출
+
+    Args:
+        menu_name: 메뉴 이름 (예: "마라탕", "짜장면")
+
+    Returns:
+        추출된 카테고리
+    """
+    if not menu_name:
+        return '기타'
+
+    menu_lower = menu_name.lower()
+
+    for keyword, category in CATEGORY_MAPPING.items():
+        if keyword.lower() in menu_lower:
+            return category
+
+    return '기타'
+
+
+class ScrapCategoryPreferenceService:
+    """스크랩 기반 카테고리 선호도 서비스"""
+
+    def __init__(self, user: User):
+        self.user = user
+
+    def get_scrap_category_counts(self) -> Dict[str, int]:
+        """
+        사용자의 스크랩에서 카테고리별 개수 집계
+
+        Returns:
+            카테고리별 개수 딕셔너리 (예: {'중식': 5, '한식': 3})
+        """
+        category_counts = Counter()
+
+        # UserRemoteScrap에서 카테고리 추출
+        remote_scraps = UserRemoteScrap.objects.filter(user=self.user)
+
+        for scrap in remote_scraps:
+            # category 필드 사용
+            if scrap.category:
+                normalized = normalize_category(scrap.category)
+                category_counts[normalized] += 1
+
+            # menu_name에서도 카테고리 추출 시도
+            if scrap.menu_name:
+                menu_category = extract_category_from_menu_name(scrap.menu_name)
+                if menu_category != '기타':
+                    category_counts[menu_category] += 1
+
+        logger.info(f"User {self.user.id} scrap category counts: {dict(category_counts)}")
+        return dict(category_counts)
+
+    def calculate_category_preferences(self) -> Dict[str, float]:
+        """
+        카테고리별 선호도 점수 계산
+
+        선호도 점수 = (해당 카테고리 스크랩 수 / 전체 스크랩 수) * 가중치
+
+        Returns:
+            카테고리별 선호도 점수 (0.0 ~ 1.0)
+        """
+        category_counts = self.get_scrap_category_counts()
+
+        if not category_counts:
+            return {}
+
+        total = sum(category_counts.values())
+        if total == 0:
+            return {}
+
+        preferences = {}
+        for category, count in category_counts.items():
+            # 기본 비율 계산
+            ratio = count / total
+
+            # 최소 스크랩 수에 따른 신뢰도 가중치 (5개 이상이면 1.0)
+            confidence = min(count / 5, 1.0)
+
+            # 최종 선호도 점수
+            preferences[category] = round(ratio * confidence, 3)
+
+        # 점수 기준 내림차순 정렬
+        preferences = dict(sorted(preferences.items(), key=lambda x: x[1], reverse=True))
+
+        logger.info(f"User {self.user.id} category preferences: {preferences}")
+        return preferences
+
+    def get_top_preferred_categories(self, top_n: int = 3) -> List[str]:
+        """
+        상위 N개의 선호 카테고리 반환
+
+        Args:
+            top_n: 반환할 카테고리 수
+
+        Returns:
+            선호도 상위 카테고리 리스트
+        """
+        preferences = self.calculate_category_preferences()
+
+        # 선호도 0.1 이상인 카테고리만 필터링
+        filtered = {k: v for k, v in preferences.items() if v >= 0.1 and k != '기타'}
+
+        return list(filtered.keys())[:top_n]
+
+    def update_user_favorite_cuisines(self) -> List[str]:
+        """
+        사용자의 favorite_cuisines를 스크랩 기반으로 업데이트
+
+        기존 favorite_cuisines와 스크랩 기반 선호도를 병합
+
+        Returns:
+            업데이트된 favorite_cuisines 리스트
+        """
+        try:
+            user_pref, created = UserPreference.objects.get_or_create(
+                user=self.user,
+                defaults={'favorite_cuisines': []}
+            )
+
+            # 기존 선호 카테고리
+            existing_cuisines = set(user_pref.favorite_cuisines or [])
+
+            # 스크랩 기반 상위 카테고리
+            scrap_based_cuisines = set(self.get_top_preferred_categories(top_n=5))
+
+            # 병합 (기존 + 스크랩 기반)
+            merged_cuisines = list(existing_cuisines | scrap_based_cuisines)
+
+            # 최대 10개로 제한
+            merged_cuisines = merged_cuisines[:10]
+
+            # 저장
+            user_pref.favorite_cuisines = merged_cuisines
+            user_pref.save(update_fields=['favorite_cuisines'])
+
+            logger.info(f"Updated favorite_cuisines for user {self.user.id}: {merged_cuisines}")
+            return merged_cuisines
+
+        except Exception as e:
+            logger.error(f"Error updating favorite_cuisines for user {self.user.id}: {e}")
+            return []
+
+    def get_category_preference_profile(self) -> Dict:
+        """
+        스크랩 기반 카테고리 선호도 프로필 반환
+
+        Returns:
+            {
+                'category_counts': {'중식': 5, '한식': 3},
+                'category_preferences': {'중식': 0.625, '한식': 0.375},
+                'top_categories': ['중식', '한식'],
+                'total_scraps': 8
+            }
+        """
+        counts = self.get_scrap_category_counts()
+        preferences = self.calculate_category_preferences()
+        top_categories = self.get_top_preferred_categories()
+
+        return {
+            'category_counts': counts,
+            'category_preferences': preferences,
+            'top_categories': top_categories,
+            'total_scraps': sum(counts.values())
+        }
+
+
+def update_category_preference_on_scrap(user: User, category: str = None, menu_name: str = None):
+    """
+    스크랩 추가 시 카테고리 선호도 업데이트 트리거
+
+    Args:
+        user: 사용자
+        category: 스크랩된 항목의 카테고리
+        menu_name: 스크랩된 메뉴 이름
+    """
+    try:
+        service = ScrapCategoryPreferenceService(user)
+        service.update_user_favorite_cuisines()
+
+        # 로깅
+        if category:
+            normalized = normalize_category(category)
+            logger.info(f"User {user.id} scrapped category: {category} -> {normalized}")
+        if menu_name:
+            menu_cat = extract_category_from_menu_name(menu_name)
+            logger.info(f"User {user.id} scrapped menu: {menu_name} -> {menu_cat}")
+
+    except Exception as e:
+        logger.error(f"Error updating category preference on scrap: {e}")
+
+

--- a/server/users/urls.py
+++ b/server/users/urls.py
@@ -1,6 +1,17 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import MeViewSet, UserViewSet, FollowViewSet, SuggestionViewSet, ScrapViewSet, OnboardingViewSet, PhotoViewSet, InteractionViewSet, RLWeightViewSet
+from .views import (
+    MeViewSet,
+    UserViewSet,
+    FollowViewSet,
+    SuggestionViewSet,
+    ScrapViewSet,
+    OnboardingViewSet,
+    PhotoViewSet,
+    InteractionViewSet,
+    RLWeightViewSet,
+    RemoteScrapViewSet,
+)
 from . import auth_views
 
 router = DefaultRouter()
@@ -9,6 +20,7 @@ router.register("users", UserViewSet, basename="users")
 router.register("follows", FollowViewSet, basename="follows")
 router.register("suggestions", SuggestionViewSet, basename="suggestions")
 router.register("scraps", ScrapViewSet, basename="scraps")
+router.register("remote-scraps", RemoteScrapViewSet, basename="remote-scraps")
 router.register("onboarding", OnboardingViewSet, basename="onboarding")
 router.register("photos", PhotoViewSet, basename="photos")
 router.register("interactions", InteractionViewSet, basename="interactions")

--- a/server/users/views.py
+++ b/server/users/views.py
@@ -4,10 +4,29 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from .models import User, Follow, UserScrap, UserPreference, UserGalleryImage, UserInteraction, RLWeightHistory
-from .serializers import UserSerializer, ProfileSerializer, FollowSerializer, UserScrapSerializer, UserPreferenceSerializer, UserGalleryImageSerializer, UserInteractionSerializer, RLWeightHistorySerializer
 from restaurant.models import Restaurant
+from .models import (
+    User,
+    Follow,
+    UserScrap,
+    UserPreference,
+    UserGalleryImage,
+    UserInteraction,
+    RLWeightHistory,
+    UserRemoteScrap,
+)
+from .serializers import (
+    UserSerializer,
+    ProfileSerializer,
+    FollowSerializer,
+    UserScrapSerializer,
+    UserPreferenceSerializer,
+    UserGalleryImageSerializer,
+    UserInteractionSerializer,
+    RLWeightHistorySerializer,
+)
 from . import services
+from .scrap_category_service import ScrapCategoryPreferenceService, update_category_preference_on_scrap
 import logging
 
 logger = logging.getLogger(__name__)
@@ -150,17 +169,17 @@ class PhotoViewSet(viewsets.ViewSet):
         """Restore gallery images from AWS metadata to database"""
         from django.utils import timezone
         from datetime import datetime
-        
+
         gallery_data = request.data
         if not isinstance(gallery_data, list):
             return Response(
                 {'error': 'Expected list of gallery items'},
                 status=status.HTTP_400_BAD_REQUEST
             )
-        
+
         restored_count = 0
         skipped_count = 0
-        
+
         for item in gallery_data:
             try:
                 # Parse datetime fields
@@ -168,17 +187,17 @@ class PhotoViewSet(viewsets.ViewSet):
                 label_edited_at = None
                 if item.get('label_edited_at'):
                     label_edited_at = datetime.fromisoformat(item['label_edited_at'].replace('Z', '+00:00'))
-                
+
                 # Check if image already exists (avoid duplicates)
                 existing = UserGalleryImage.objects.filter(
                     user=request.user,
                     image_url=item['image_url']
                 ).first()
-                
+
                 if existing:
                     skipped_count += 1
                     continue
-                
+
                 # Create gallery image record
                 UserGalleryImage.objects.create(
                     user=request.user,
@@ -195,11 +214,11 @@ class PhotoViewSet(viewsets.ViewSet):
                     created_at=created_at,
                 )
                 restored_count += 1
-                
+
             except Exception as e:
                 logger.error(f"Error restoring gallery item: {e}")
                 continue
-        
+
         return Response({
             'message': f'Successfully restored {restored_count} gallery items, skipped {skipped_count} duplicates',
             'restored': restored_count,
@@ -365,7 +384,7 @@ class ScrapViewSet(viewsets.GenericViewSet):
         print(f"🍽️ DEBUG TOGGLE: Restaurant ID {restaurant_id}, Name: {restaurant_name}")
 
         restaurant = None
-        
+
         if restaurant_id:
             try:
                 # First try to find by Django model ID (integer)
@@ -377,7 +396,7 @@ class ScrapViewSet(viewsets.GenericViewSet):
                     print(f"🎯 DEBUG TOGGLE: Found restaurant by source UUID - Django ID: {restaurant.id}")
                 except Restaurant.DoesNotExist:
                     pass
-        
+
         # If no restaurant found by ID, try to find by name
         if not restaurant and restaurant_name:
             try:
@@ -389,39 +408,39 @@ class ScrapViewSet(viewsets.GenericViewSet):
                 similar = Restaurant.objects.filter(name__icontains=restaurant_name.split()[0])[:3]
                 print(f"🔍 DEBUG TOGGLE: Similar restaurants: {[r.name for r in similar]}")
                 pass
-        
+
         # If restaurant still not found, try to create it from recommendation system data
         if not restaurant and restaurant_id and restaurant_name:
             try:
                 # Query the recommendation database to get restaurant details
                 from psql.preprocess.preprocess import get_db_connection
                 import uuid
-                
+
                 # Validate UUID format
                 try:
                     uuid.UUID(restaurant_id)
                     is_valid_uuid = True
                 except ValueError:
                     is_valid_uuid = False
-                
+
                 if is_valid_uuid:
                     conn = get_db_connection()
                     cursor = conn.cursor()
-                    
+
                     try:
                         # Query restaurant from recommendation database
                         cursor.execute("""
                             SELECT name, address, ST_Y(geom::geometry) as latitude, ST_X(geom::geometry) as longitude
-                            FROM db_restaurants 
+                            FROM db_restaurants
                             WHERE id = %s
                         """, [restaurant_id])
-                        
+
                         restaurant_data = cursor.fetchone()
-                        
+
                         if restaurant_data:
                             name, address, lat, lng = restaurant_data
                             print(f"🏗️ DEBUG TOGGLE: Creating new restaurant from recommendation data: {name}")
-                            
+
                             # Create new restaurant in Django ORM
                             restaurant = Restaurant.objects.create(
                                 name=name,
@@ -438,10 +457,10 @@ class ScrapViewSet(viewsets.GenericViewSet):
                     finally:
                         cursor.close()
                         conn.close()
-                        
+
             except Exception as create_error:
                 print(f"❌ DEBUG TOGGLE: Error creating restaurant: {create_error}")
-        
+
         if not restaurant:
             return Response(
                 {"error": "restaurant_id or restaurant_name is required and must match an existing restaurant"},
@@ -494,46 +513,46 @@ class ScrapViewSet(viewsets.GenericViewSet):
     def _is_aws_configured(self):
         """Check if AWS credentials are properly configured"""
         from django.conf import settings
-        
+
         aws_key = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
         aws_secret = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
-        
+
         # Check if credentials exist and are not placeholder values
-        return bool(aws_key and aws_secret and 
-                   aws_key != 'placeholder_key' and 
+        return bool(aws_key and aws_secret and
+                   aws_key != 'placeholder_key' and
                    aws_secret != 'placeholder_secret' and
                    aws_key.strip() and aws_secret.strip())
-    
+
     def _upload_to_local_storage(self, user_id, username, scraps_data):
         """Fallback: Store scraps in local file storage"""
         import json
         import os
         from django.conf import settings
-        
+
         # Create user scraps directory
         base_dir = getattr(settings, 'BASE_DIR', '/tmp')
         scraps_dir = os.path.join(base_dir, 'user_scraps', str(user_id))
         os.makedirs(scraps_dir, exist_ok=True)
-        
+
         # Write scraps to JSON file
         scraps_file = os.path.join(scraps_dir, 'scraps.json')
         scraps_json = json.dumps(scraps_data, indent=2, ensure_ascii=False)
-        
+
         with open(scraps_file, 'w', encoding='utf-8') as f:
             f.write(scraps_json)
-        
+
         print(f"✅ Successfully stored {len(scraps_data)} scraps locally: {scraps_file}")
         return scraps_file
-    
+
     def _download_from_local_storage(self, user_id):
         """Fallback: Load scraps from local file storage"""
         import json
         import os
         from django.conf import settings
-        
+
         base_dir = getattr(settings, 'BASE_DIR', '/tmp')
         scraps_file = os.path.join(base_dir, 'user_scraps', str(user_id), 'scraps.json')
-        
+
         if os.path.exists(scraps_file):
             with open(scraps_file, 'r', encoding='utf-8') as f:
                 scraps_data = json.load(f)
@@ -548,24 +567,24 @@ class ScrapViewSet(viewsets.GenericViewSet):
         """원격 저장소에 스크랩 데이터 업로드 (AWS S3 또는 로컬 저장소 폴백)"""
         import json
         from django.conf import settings
-        
+
         scraps_data = request.data.get('scraps', [])
-        
+
         if not request.user.is_authenticated:
             return Response(
                 {"error": "Authentication required"},
                 status=status.HTTP_401_UNAUTHORIZED
             )
-        
+
         print(f"📤 Remote Upload: Processing {len(scraps_data)} scraps for user {request.user.username} (ID: {request.user.id})")
-        
+
         # Check if AWS is properly configured
         if self._is_aws_configured():
             # Use real AWS S3
             try:
                 import boto3
                 from botocore.exceptions import ClientError, NoCredentialsError
-                
+
                 # Initialize S3 client
                 s3_client = boto3.client(
                     's3',
@@ -573,14 +592,14 @@ class ScrapViewSet(viewsets.GenericViewSet):
                     aws_secret_access_key=getattr(settings, 'AWS_SECRET_ACCESS_KEY'),
                     region_name=getattr(settings, 'AWS_S3_REGION_NAME', 'us-east-1')
                 )
-                
+
                 # S3 bucket and file path
                 bucket_name = getattr(settings, 'AWS_STORAGE_BUCKET_NAME', 'swpp-foodigram-storage')
                 file_key = f"user-scraps/{request.user.id}/scraps.json"
-                
+
                 # Convert scraps data to JSON
                 scraps_json = json.dumps(scraps_data, indent=2, ensure_ascii=False)
-                
+
                 # Upload to S3
                 s3_client.put_object(
                     Bucket=bucket_name,
@@ -593,18 +612,18 @@ class ScrapViewSet(viewsets.GenericViewSet):
                         'upload_timestamp': str(timezone.now().isoformat())
                     }
                 )
-                
+
                 print(f"✅ Successfully uploaded {len(scraps_data)} scraps to S3: s3://{bucket_name}/{file_key}")
-                
+
                 return Response(
                     {"message": f"Successfully uploaded {len(scraps_data)} scraps to AWS S3"},
                     status=status.HTTP_200_OK
                 )
-                
+
             except Exception as e:
                 print(f"❌ AWS S3 upload failed: {e}")
                 print("🔄 Falling back to local storage...")
-                
+
                 # Fallback to local storage
                 try:
                     self._upload_to_local_storage(request.user.id, request.user.username, scraps_data)
@@ -639,17 +658,17 @@ class ScrapViewSet(viewsets.GenericViewSet):
         """갤러리 이미지 메타데이터를 원격 저장소에 업로드 (AWS S3 또는 로컬 저장소 폴백)"""
         import json
         from django.conf import settings
-        
+
         if not request.user.is_authenticated:
             return Response(
                 {"error": "Authentication required"},
                 status=status.HTTP_401_UNAUTHORIZED
             )
-        
+
         # Get current gallery images from database
         gallery_images = UserGalleryImage.objects.filter(user=request.user)
         gallery_data = []
-        
+
         for image in gallery_images:
             gallery_data.append({
                 "image_url": image.image_url,
@@ -664,16 +683,16 @@ class ScrapViewSet(viewsets.GenericViewSet):
                 "local_uri": image.local_uri,
                 "created_at": image.created_at.isoformat(),
             })
-        
+
         print(f"📤 Remote Gallery Upload: Processing {len(gallery_data)} gallery images for user {request.user.username} (ID: {request.user.id})")
-        
+
         # Check if AWS is properly configured
         if self._is_aws_configured():
             # Use real AWS S3
             try:
                 import boto3
                 from botocore.exceptions import ClientError, NoCredentialsError
-                
+
                 # Initialize S3 client
                 s3_client = boto3.client(
                     's3',
@@ -681,11 +700,11 @@ class ScrapViewSet(viewsets.GenericViewSet):
                     aws_secret_access_key=getattr(settings, 'AWS_SECRET_ACCESS_KEY'),
                     region_name=getattr(settings, 'AWS_S3_REGION_NAME', 'us-east-1')
                 )
-                
+
                 # S3 bucket and file path
                 bucket_name = getattr(settings, 'AWS_STORAGE_BUCKET_NAME', 'swpp-foodigram-storage')
                 file_key = f"user-gallery/{request.user.id}/gallery.json"
-                
+
                 # Upload to S3
                 gallery_json = json.dumps(gallery_data, ensure_ascii=False, indent=2)
                 s3_client.put_object(
@@ -694,18 +713,18 @@ class ScrapViewSet(viewsets.GenericViewSet):
                     Body=gallery_json.encode('utf-8'),
                     ContentType='application/json'
                 )
-                
+
                 print(f"✅ Successfully uploaded {len(gallery_data)} gallery images to S3: s3://{bucket_name}/{file_key}")
-                
+
                 return Response(
                     {"message": f"Successfully uploaded {len(gallery_data)} gallery images to S3"},
                     status=status.HTTP_200_OK
                 )
-                
+
             except Exception as e:
                 print(f"❌ AWS S3 gallery upload failed: {e}")
                 print("🔄 Falling back to local storage...")
-                
+
                 # Fallback to local storage
                 try:
                     self._upload_gallery_to_local_storage(request.user.id, request.user.username, gallery_data)
@@ -740,22 +759,22 @@ class ScrapViewSet(viewsets.GenericViewSet):
         """원격 저장소에서 갤러리 이미지 메타데이터 다운로드 (AWS S3 또는 로컬 저장소 폴백)"""
         import json
         from django.conf import settings
-        
+
         if not request.user.is_authenticated:
             return Response(
                 {"error": "Authentication required"},
                 status=status.HTTP_401_UNAUTHORIZED
             )
-        
+
         print(f"📥 Remote Gallery Download: Fetching gallery images for user {request.user.username} (ID: {request.user.id})")
-        
+
         # Check if AWS is properly configured
         if self._is_aws_configured():
             # Use real AWS S3
             try:
                 import boto3
                 from botocore.exceptions import ClientError, NoCredentialsError
-                
+
                 # Initialize S3 client
                 s3_client = boto3.client(
                     's3',
@@ -763,21 +782,21 @@ class ScrapViewSet(viewsets.GenericViewSet):
                     aws_secret_access_key=getattr(settings, 'AWS_SECRET_ACCESS_KEY'),
                     region_name=getattr(settings, 'AWS_S3_REGION_NAME', 'us-east-1')
                 )
-                
+
                 # S3 bucket and file path
                 bucket_name = getattr(settings, 'AWS_STORAGE_BUCKET_NAME', 'swpp-foodigram-storage')
                 file_key = f"user-gallery/{request.user.id}/gallery.json"
-                
+
                 # Download from S3
                 try:
                     response = s3_client.get_object(Bucket=bucket_name, Key=file_key)
                     gallery_json = response['Body'].read().decode('utf-8')
                     gallery_data = json.loads(gallery_json)
-                    
+
                     print(f"✅ Successfully downloaded {len(gallery_data)} gallery images from S3: s3://{bucket_name}/{file_key}")
-                    
+
                     return Response(gallery_data, status=status.HTTP_200_OK)
-                    
+
                 except ClientError as e:
                     error_code = e.response['Error']['Code']
                     if error_code == 'NoSuchKey':
@@ -785,11 +804,11 @@ class ScrapViewSet(viewsets.GenericViewSet):
                         return Response([], status=status.HTTP_200_OK)
                     else:
                         raise e
-                
+
             except Exception as e:
                 print(f"❌ AWS S3 gallery download failed: {e}")
                 print("🔄 Falling back to local storage...")
-                
+
                 # Fallback to local storage
                 try:
                     gallery_data = self._download_gallery_from_local_storage(request.user.id)
@@ -813,27 +832,27 @@ class ScrapViewSet(viewsets.GenericViewSet):
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR
                 )
 
-    @action(detail=False, methods=['get'], url_path='download-from-aws')  
+    @action(detail=False, methods=['get'], url_path='download-from-aws')
     def download_from_aws(self, request):
         """원격 저장소에서 스크랩 데이터 다운로드 (AWS S3 또는 로컬 저장소 폴백)"""
         import json
         from django.conf import settings
-        
+
         if not request.user.is_authenticated:
             return Response(
                 {"error": "Authentication required"},
                 status=status.HTTP_401_UNAUTHORIZED
             )
-        
+
         print(f"📥 Remote Download: Fetching scraps for user {request.user.username} (ID: {request.user.id})")
-        
+
         # Check if AWS is properly configured
         if self._is_aws_configured():
             # Use real AWS S3
             try:
                 import boto3
                 from botocore.exceptions import ClientError, NoCredentialsError
-                
+
                 # Initialize S3 client
                 s3_client = boto3.client(
                     's3',
@@ -841,21 +860,21 @@ class ScrapViewSet(viewsets.GenericViewSet):
                     aws_secret_access_key=getattr(settings, 'AWS_SECRET_ACCESS_KEY'),
                     region_name=getattr(settings, 'AWS_S3_REGION_NAME', 'us-east-1')
                 )
-                
+
                 # S3 bucket and file path
                 bucket_name = getattr(settings, 'AWS_STORAGE_BUCKET_NAME', 'swpp-foodigram-storage')
                 file_key = f"user-scraps/{request.user.id}/scraps.json"
-                
+
                 # Download from S3
                 try:
                     response = s3_client.get_object(Bucket=bucket_name, Key=file_key)
                     scraps_json = response['Body'].read().decode('utf-8')
                     scraps_data = json.loads(scraps_json)
-                    
+
                     print(f"✅ Successfully downloaded {len(scraps_data)} scraps from S3: s3://{bucket_name}/{file_key}")
-                    
+
                     return Response(scraps_data, status=status.HTTP_200_OK)
-                    
+
                 except ClientError as e:
                     error_code = e.response['Error']['Code']
                     if error_code == 'NoSuchKey':
@@ -863,11 +882,11 @@ class ScrapViewSet(viewsets.GenericViewSet):
                         return Response([], status=status.HTTP_200_OK)
                     else:
                         raise e
-                
+
             except Exception as e:
                 print(f"❌ AWS S3 download failed: {e}")
                 print("🔄 Falling back to local storage...")
-                
+
                 # Fallback to local storage
                 try:
                     scraps_data = self._download_from_local_storage(request.user.id)
@@ -896,19 +915,19 @@ class ScrapViewSet(viewsets.GenericViewSet):
         import json
         import os
         from django.conf import settings
-        
+
         # Create user gallery directory
         base_dir = getattr(settings, 'BASE_DIR', '/tmp')
         gallery_dir = os.path.join(base_dir, 'user_gallery', str(user_id))
         os.makedirs(gallery_dir, exist_ok=True)
-        
+
         # Write gallery data to JSON file
         gallery_file = os.path.join(gallery_dir, 'gallery.json')
         gallery_json = json.dumps(gallery_data, indent=2, ensure_ascii=False)
-        
+
         with open(gallery_file, 'w', encoding='utf-8') as f:
             f.write(gallery_json)
-        
+
         print(f"✅ Successfully stored {len(gallery_data)} gallery images locally: {gallery_file}")
 
     def _download_gallery_from_local_storage(self, user_id):
@@ -916,10 +935,10 @@ class ScrapViewSet(viewsets.GenericViewSet):
         import json
         import os
         from django.conf import settings
-        
+
         base_dir = getattr(settings, 'BASE_DIR', '/tmp')
         gallery_file = os.path.join(base_dir, 'user_gallery', str(user_id), 'gallery.json')
-        
+
         if os.path.exists(gallery_file):
             with open(gallery_file, 'r', encoding='utf-8') as f:
                 gallery_data = json.load(f)
@@ -934,11 +953,11 @@ class OnboardingViewSet(viewsets.GenericViewSet):
     """온보딩 취향 설정 API"""
     permission_classes = [IsAuthenticated]
     serializer_class = UserPreferenceSerializer
-    
+
     def get_queryset(self):
         """현재 유저의 취향 설정만 조회"""
         return UserPreference.objects.filter(user=self.request.user)
-    
+
     def list(self, request):
         """내 취향 설정 조회"""
         preference = UserPreference.objects.filter(user=request.user).first()
@@ -950,11 +969,11 @@ class OnboardingViewSet(viewsets.GenericViewSet):
                 {"message": "No preferences set yet"},
                 status=status.HTTP_404_NOT_FOUND
             )
-    
+
     def create(self, request):
         """취향 설정 생성/업데이트"""
         from django.db import transaction, IntegrityError
-        
+
         try:
             with transaction.atomic():
                 preference, created = UserPreference.objects.get_or_create(
@@ -976,7 +995,7 @@ class OnboardingViewSet(viewsets.GenericViewSet):
             except UserPreference.DoesNotExist:
                 # If still doesn't exist, re-raise the error
                 raise
-        
+
         if not created:
             # 기존 설정 업데이트
             serializer = self.get_serializer(preference, data=request.data, partial=True)
@@ -986,12 +1005,12 @@ class OnboardingViewSet(viewsets.GenericViewSet):
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         else:
             serializer = self.get_serializer(preference)
-        
+
         return Response(
-            serializer.data, 
+            serializer.data,
             status=status.HTTP_201_CREATED if created else status.HTTP_200_OK
         )
-    
+
     @action(detail=False, methods=['patch'], url_path='update')
     def update_preferences(self, request):
         """취향 설정 부분 업데이트"""
@@ -1187,3 +1206,112 @@ class RLWeightViewSet(viewsets.GenericViewSet):
 
         serializer = self.get_serializer(weight_entry)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class RemoteScrapViewSet(viewsets.GenericViewSet):
+    """원격 스크랩 동기화 API - 카테고리 정보 포함"""
+
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        return UserRemoteScrap.objects.filter(user=self.request.user)
+
+    def list(self, request):
+        """원격 스크랩 목록 조회"""
+        scraps = self.get_queryset().order_by('-scrapped_at')
+        data = []
+        for scrap in scraps:
+            data.append({
+                'menu_id': scrap.menu_id,
+                'menu_name': scrap.menu_name,
+                'place_name': scrap.place_name,
+                'price': scrap.price,
+                'category': scrap.category,
+                'location': scrap.location,
+                'rating': scrap.rating,
+                'review_count': scrap.review_count,
+                'image_url': scrap.image_url,
+                'coordinates': scrap.coordinates,
+                'scrapped_at': scrap.scrapped_at.isoformat(),
+                'synced_at': scrap.synced_at.isoformat(),
+            })
+        return Response(data)
+
+    def create(self, request):
+        """원격 스크랩 생성/동기화"""
+        from django.utils.dateparse import parse_datetime
+
+        scraps_data = request.data.get('scraps', [])
+        if not isinstance(scraps_data, list):
+            scraps_data = [request.data]
+
+        created_count = 0
+        updated_count = 0
+
+        for scrap_data in scraps_data:
+            menu_id = scrap_data.get('menu_id')
+            if not menu_id:
+                continue
+
+            scrapped_at = scrap_data.get('scrapped_at')
+            if isinstance(scrapped_at, str):
+                scrapped_at = parse_datetime(scrapped_at) or timezone.now()
+            else:
+                scrapped_at = timezone.now()
+
+            defaults = {
+                'menu_name': scrap_data.get('menu_name', ''),
+                'place_name': scrap_data.get('place_name', ''),
+                'price': scrap_data.get('price'),
+                'category': scrap_data.get('category', ''),
+                'location': scrap_data.get('location', ''),
+                'rating': scrap_data.get('rating'),
+                'review_count': scrap_data.get('review_count'),
+                'image_url': scrap_data.get('image_url', ''),
+                'coordinates': scrap_data.get('coordinates', []),
+                'scrapped_at': scrapped_at,
+            }
+
+            _, created = UserRemoteScrap.objects.update_or_create(
+                user=request.user,
+                menu_id=menu_id,
+                defaults=defaults
+            )
+
+            if created:
+                created_count += 1
+            else:
+                updated_count += 1
+
+        try:
+            service = ScrapCategoryPreferenceService(request.user)
+            updated_cuisines = service.update_user_favorite_cuisines()
+            logger.info(f"User {request.user.id} category preferences updated: {updated_cuisines}")
+        except Exception as e:
+            logger.warning(f"Failed to update category preferences after remote sync: {e}")
+
+        return Response({
+            'message': 'Scraps synced successfully',
+            'created': created_count,
+            'updated': updated_count,
+        }, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=['get'], url_path='category-preferences')
+    def category_preferences(self, request):
+        """스크랩 기반 카테고리 선호도 조회"""
+        service = ScrapCategoryPreferenceService(request.user)
+        profile = service.get_category_preference_profile()
+        return Response(profile)
+
+    @action(detail=False, methods=['post'], url_path='refresh-preferences')
+    def refresh_preferences(self, request):
+        """스크랩 기반 카테고리 선호도 수동 갱신"""
+        service = ScrapCategoryPreferenceService(request.user)
+        updated_cuisines = service.update_user_favorite_cuisines()
+        profile = service.get_category_preference_profile()
+
+        return Response({
+            'message': 'Category preferences updated',
+            'updated_cuisines': updated_cuisines,
+            'profile': profile
+        })

--- a/server/users/views.py
+++ b/server/users/views.py
@@ -504,6 +504,14 @@ class ScrapViewSet(viewsets.GenericViewSet):
             )
             logger.info(f"User {request.user.id} toggled on scrap for restaurant {restaurant_id} - logged interaction")
 
+            # 스크랩 기반 카테고리 선호도 업데이트
+            try:
+                category = request.data.get('category', '')
+                menu_name = request.data.get('menu_name', '')
+                update_category_preference_on_scrap(request.user, category=category, menu_name=menu_name)
+            except Exception as e:
+                logger.warning(f"Failed to update category preference: {e}")
+
             serializer = self.get_serializer(scrap)
             return Response(
                 {"scrapped": True, "data": serializer.data},


### PR DESCRIPTION
스크랩 토글로 새 항목을 추가할 때 update_category_preference_on_scrap을 호출해 스크랩 기반 카테고리 선호도를 즉시 갱신하게 했습니다
예외가 발생해도 전체 토글 흐름이 중단되지 않도록 try/catch로 감싸고 로그 남깁니다

테스트: 로컬에서 스크랩 토글 API 호출 시 오류 없이 선호도 업데이트 로그 확인